### PR TITLE
Embed Events on Stream Page

### DIFF
--- a/cmd/api/router.go
+++ b/cmd/api/router.go
@@ -6,10 +6,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	twitch_api_base = "https://api.twitch.tv/helix/"
-)
-
 type Router struct {
 	logger *zap.Logger
 	router *routing.Router
@@ -30,7 +26,7 @@ func (r *Router) RegisterAndRun() error {
 	router.Get("/", r.ShowLoginPage)
 
 	router.Get("/streams", r.ListStreams)
-	router.Get("/streams/<id>", r.ShowStreamPage)
+	router.Get("/streams/<name>", r.ShowStreamPage)
 
 	r.logger.Info("HTTP service started on:", zap.String("address", "127.0.0.1:6121"))
 	return fasthttp.ListenAndServe(":8080", router.HandleRequest)

--- a/templates/stream_embed.html
+++ b/templates/stream_embed.html
@@ -27,5 +27,9 @@
         </iframe>
     </div>
 </div>
+<div id="twitch-channel-events">
+    Total Events: {{ .EventsFrame.Total }}<br>
+    Events: {{ .EventsFrame.Events }}
+</div>
 </body>
 </html>

--- a/templates/stream_list.html
+++ b/templates/stream_list.html
@@ -10,7 +10,7 @@
 {{ range .Streams }}
     <div>
         <img src="{{ .ThumbURL }}"/>
-        <a href="http://localhost:8080/streams/{{ .UserName }}">{{ .Title }}</a><br>
+        <a href="http://localhost:8080/streams/{{ .UserName }}?id={{ .ID }}">{{ .Title }}</a><br>
     </div>
 {{ end }}
 </ul>


### PR DESCRIPTION
Events rely on non-documented API (non-official endpoints) as per https://discuss.dev.twitch.tv/t/how-to-access-twitch-events/20151 and therefore "it can break or change at any time" because it's support not guaranteed from Twitch Backend team.